### PR TITLE
Fix Model A bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# vscode settings
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ $ source activate <your venv>
 $ make init-repo-setup
 ```
 
+# Credentials
+The project uses 3rd party API to provide services such as
+- Speech-to-Text Models (i.e., Model A)
+- LLM Models (i.e., Model B)
+- Text-to-Speech Models (i.e., Model C)
+
+To use these services at the local env, user need to set up credentials at the local.
+For example, Model A has Whisper from OpenAI or the STT from Google, then user needs
+the corresponding credential from different service providers.
+- For Google services, please firstly create a [GOOGLE_APPLICATION_CREDENTIALS](https://docs.cloud.google.com/docs/authentication/application-default-credentials#GAC) envrionment variable, which should stores the path to the `.json` file that stores your GCP credential.
+  - For more details see: https://docs.cloud.google.com/docs/authentication/set-up-adc-local-dev-environment#google-account  (Trouble shoot: https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#user-creds-client-based)
+  - For service account authorization, see: [Cockatoo_Chain Wiki](https://github.com/Cockatoo-AI-Org/cockatoo_chain/wiki)
+
+
+
+
 # Model A Usage
 From `cockagoo_chain` package, you can easily access the power of Model A (Speech-to-text) with a few lines of codes. We will learn how to from this section. For the time being, `cockagoo_chain` support below types of model A:
 
@@ -56,7 +72,8 @@ You can use below code snippet to get the supported model A options:
 >>> from cockatoo_chain.utils import model_a
 >>> model_type = model_a.ModelType
 >>> list(model_type)
-[<ModelType.OPEN_AI_WHISPER: 'open_ai_whisper'>]
+[<ModelType.OPEN_AI_WHISPER: 'open_ai_whisper'>,
+ <ModelType.GCP_STT: 'gcp_stt'>]
 ```
 
 ## Transform input audio file into text
@@ -101,3 +118,7 @@ Text2AudioData(
     spent_time_sec=1.822951,
     generated_audio_file_path='/tmp/gcp_tts_output.wav')
 ```
+
+## References
+- [LangChain Integration Lab Model A,B,C- John Lee](https://github.com/Cockatoo-AI-Org/Cockatoo.AI/blob/master/experiments/model_a_eval/langchain_integrate_lab.ipynb)
+-

--- a/cockatoo_chain/utils/model_a/gcp.py
+++ b/cockatoo_chain/utils/model_a/gcp.py
@@ -1,4 +1,5 @@
 """Wrapper of GCP STT solution."""
+from typing import Any
 import logging
 import os
 import time
@@ -6,7 +7,6 @@ import wave
 from google.cloud import speech as stt
 # from google.cloud import speech_v2 as stt
 from google.oauth2 import service_account
-
 from cockatoo_chain.utils import wrapper
 from cockatoo_chain.utils.model_a import base
 
@@ -35,13 +35,14 @@ class GCPSpeech2TextWrapper(ModelBase):
     supported language code, refer to:
     https://cloud.google.com/speech-to-text/docs/speech-to-text-supported-languages
   """
-  def __init__(self, settings):
+
+  def __init__(self, settings: dict[str, Any]):
     super().__init__(settings['lang'])
     key_path = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
     self._credentials = service_account.Credentials.from_service_account_file(
-        key_path,
-        scopes=[
-            'https://www.googleapis.com/auth/cloud-platform'])
+      key_path,
+      scopes=['https://www.googleapis.com/auth/cloud-platform']
+    )
     logging.info('Start authorizing...')
     self._client = stt.SpeechClient()
     self._input_path = settings.get('audio_input_path', AUDIO_INPUT_PATH)
@@ -61,7 +62,7 @@ class GCPSpeech2TextWrapper(ModelBase):
     with wave.open(audio_file_path, 'rb') as wave_file:
       frame_rate = wave_file.getframerate()
       channels = wave_file.getnchannels()
-      return frame_rate, channels
+    return frame_rate, channels
 
   def audio_2_text(self, audio_file_path: str | None = None) -> Audio2TextData:
     """Turns audio from input audio file into text."""

--- a/cockatoo_chain/utils/model_a/open_ai.py
+++ b/cockatoo_chain/utils/model_a/open_ai.py
@@ -1,4 +1,5 @@
 """Wrapper of package `speech_recognition`."""
+from typing import Any
 import logging
 import openai
 import os
@@ -28,8 +29,9 @@ class OpenAIWrapper(ModelBase):
   """
 
   def __init__(
-      self, lang: wrapper.LangEnum, model: str = 'whisper-1'):
-    super().__init__(lang)
+    self, settings: dict[str, Any], model: str = 'whisper-1'
+  ):
+    super().__init__(settings['lang'])
     self._client = openai.OpenAI()
     self._model = model
 
@@ -49,9 +51,10 @@ class OpenAIWrapper(ModelBase):
     start_time = time.time()
     try:
       # Using Whisper API
-      transcription = self.client.audio.transcriptions.create(
-          model=self._model,
-          file=open(audio_file_path, 'rb'))
+      with open(audio_file_path, 'rb') as audio_file:
+        transcription = self.client.audio.transcriptions.create(
+            model=self._model,
+            file=audio_file)
 
       audio_text = transcription.text
       time_diff_sec = time.time() - start_time

--- a/tests/test_model_a_gcp.py
+++ b/tests/test_model_a_gcp.py
@@ -1,5 +1,6 @@
 from cockatoo_chain.utils.model_a import gcp
 from cockatoo_chain.utils import wrapper
+import os
 import tempfile
 import unittest
 from unittest import mock
@@ -42,8 +43,11 @@ class TestCockatooChain(unittest.TestCase):
     self.gcp_wrapper._frame_rate_channel = mock.MagicMock(
       return_value=(1, 2))
 
-    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
-      test_file_path = temp_file.name
+    with tempfile.TemporaryDirectory() as temp_dir:
+      # mock reading audio file
+      test_file_path = os.path.join(temp_dir, 'test_audio.wav')
+      with open(test_file_path, 'wb') as f:
+        f.write('fake audio content'.encode('utf-8'))
       response = self.gcp_wrapper.audio_2_text(test_file_path)
 
       self.assertEqual(response.text, 'helloworld')

--- a/tests/test_model_a_open_ai.py
+++ b/tests/test_model_a_open_ai.py
@@ -1,5 +1,6 @@
 from cockatoo_chain.utils.model_a import open_ai
 from cockatoo_chain.utils import wrapper
+import os
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -18,12 +19,12 @@ class TestCockatooChain(unittest.TestCase):
 
   def test_open_ai_wrapper_attributes(self):
     """Test function `load_env`."""
-    test_lang = LangEnum.en
+    settings = {'lang': LangEnum.en}
     mock_open_ai_client = self.mock_open_ai.OpenAI.return_value
 
-    open_ai_wrapper = open_ai.OpenAIWrapper(test_lang)
+    open_ai_wrapper = open_ai.OpenAIWrapper(settings)
 
-    self.assertEqual(open_ai_wrapper.lang, test_lang)
+    self.assertEqual(open_ai_wrapper.lang, settings['lang'])
     self.assertEqual(open_ai_wrapper.client, mock_open_ai_client)
     self.assertEqual(open_ai_wrapper.name, 'OpenAI/speech-to-text')
 
@@ -31,18 +32,21 @@ class TestCockatooChain(unittest.TestCase):
   def test_open_ai_wrapper_audio_2_text(self, mock_time):
     """Test method `wrapper.audio_2_text(...)`."""
     mock_time.time.side_effect = [0, 1]
-    with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
-      test_lang = LangEnum.cn
-      test_file_path = temp_file.name
-      mock_open_ai_client = self.mock_open_ai.OpenAI.return_value
-      mock_transcription = (
-          mock_open_ai_client.audio.transcriptions.create.return_value)
-      mock_transcription.text = 'helloworld'
-      open_ai_wrapper = open_ai.OpenAIWrapper(test_lang)
+    mock_open_ai_client = self.mock_open_ai.OpenAI.return_value
+    mock_transcription = (
+      mock_open_ai_client.audio.transcriptions.create.return_value)
+    mock_transcription.text = 'helloworld'
+    settings = {'lang': LangEnum.cn}
 
+    with tempfile.TemporaryDirectory() as temp_dir:
+      # mock reading audio file
+      test_file_path = os.path.join(temp_dir, 'test_audio.wav')
+      with open(test_file_path, 'wb') as f:
+        f.write('fake audio content'.encode('utf-8'))
+      open_ai_wrapper = open_ai.OpenAIWrapper(settings)
       response = open_ai_wrapper.audio_2_text(test_file_path)
 
-      self.assertEqual(open_ai_wrapper.lang, test_lang)
+      self.assertEqual(open_ai_wrapper.lang, settings['lang'])
       self.assertEqual(response.text, 'helloworld')
       self.assertEqual(response.spent_time_sec, 1)
       self.assertEqual(response.audio_file_path, test_file_path)
@@ -54,17 +58,17 @@ class TestCockatooChain(unittest.TestCase):
     mock_open_ai_client = self.mock_open_ai.OpenAI.return_value
     mock_open_ai_client.audio.transcriptions.create.side_effect = (
         Exception('test'))
-    open_ai_wrapper = open_ai.OpenAIWrapper(LangEnum.cn)
+    open_ai_wrapper = open_ai.OpenAIWrapper({'lang': LangEnum.cn})
     with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
       with self.assertRaises(Exception):
         open_ai_wrapper.audio_2_text(temp_file.name)
 
   def test_open_ai_wrapper_live_2_text(self):
     """Test method `wrapper.live_2_text(...)`."""
-    test_lang = LangEnum.cn
+    settings = {'lang': LangEnum.cn}
     test_record_time_sec = 1
     test_output_audio_file_path = 'test_output_audio_file_path'
-    open_ai_wrapper = open_ai.OpenAIWrapper(test_lang)
+    open_ai_wrapper = open_ai.OpenAIWrapper(settings)
 
     with self.assertRaises(NotImplementedError):
       open_ai_wrapper.live_2_text(


### PR DESCRIPTION
the PR:
- fixes the parameters discrepency in `__init__`  of modelA classes in comparison to the `model_a.get` method
- fixes the bug for `pytest` (well, permission denied for a tempfile because that tempfile has been opened twice, which is not allowed)

The focus of the branch is to wrap model A and C in the repo as Flask API, but before that this PR is needed to solve existing bug.

Interesting thing is that, the bug happens for Windows env, but not in Linux, because I have created a dummy PR from develop to main branch to check if develop branch can pass CI test (well, it passed...) (see PR #17 )

<img width="1652" height="1000" alt="image" src="https://github.com/user-attachments/assets/50ce7c72-0abd-4f44-a9a9-2221ae2ef36b" />
